### PR TITLE
Fixed E_WARNING message when NSQ is unavailable

### DIFF
--- a/src/nsqphp/Connection/Connection.php
+++ b/src/nsqphp/Connection/Connection.php
@@ -215,7 +215,7 @@ class Connection implements ConnectionInterface
     public function getSocket()
     {
         if ($this->socket === NULL) {
-            $this->socket = fsockopen($this->hostname, $this->port, $errNo, $errStr, $this->connectionTimeout);
+            $this->socket = @fsockopen($this->hostname, $this->port, $errNo, $errStr, $this->connectionTimeout);
             if ($this->socket === FALSE) {
                 throw new ConnectionException(
                         "Could not connect to {$this->hostname}:{$this->port} ({$errStr} [{$errNo}])"


### PR DESCRIPTION
If NSQ is unavailable and error reporting E_WARNING is enabled, ConnectionException is thrown successfully.